### PR TITLE
Added support for macOS & watchOS

### DIFF
--- a/Sources/ImageWithActivityIndicator/ActivityIndicator.swift
+++ b/Sources/ImageWithActivityIndicator/ActivityIndicator.swift
@@ -7,6 +7,7 @@
 //
 import SwiftUI
 
+#if os(iOS)
 @available(iOS 13.0, *)
 public struct ActivityIndicator: UIViewRepresentable {
     
@@ -20,3 +21,4 @@ public struct ActivityIndicator: UIViewRepresentable {
         uiView.startAnimating()
     }
 }
+#endif

--- a/Sources/ImageWithActivityIndicator/ActivityIndicator.swift
+++ b/Sources/ImageWithActivityIndicator/ActivityIndicator.swift
@@ -7,8 +7,9 @@
 //
 import SwiftUI
 
-#if os(iOS)
+#if !os(watchOS)
 @available(iOS 13.0, *)
+@available(OSX 10.15, *)
 public struct ActivityIndicator: UIViewRepresentable {
     
     let style: UIActivityIndicatorView.Style

--- a/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
+++ b/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
@@ -10,9 +10,11 @@ import SwiftUI
 
 
 @available(iOS 13.0, *)
+@available(watchOS 6.0, *)
 public struct ViewWithActivityIndicator<Content:View> : View {
-
+    #if os(iOS)
     private let style: UIActivityIndicatorView.Style = .medium
+    #endif
 
     @ObservedObject private var viewLoader:ViewLoader
     private var content: () -> Content
@@ -36,7 +38,9 @@ public struct ViewWithActivityIndicator<Content:View> : View {
                     }
                     
                     if showActivityIndicator {
+                        #if os(iOS)
                         ActivityIndicator(style: .large)
+                        #endif
                     }
                 }
                 else{
@@ -56,6 +60,7 @@ public struct ViewWithActivityIndicator<Content:View> : View {
 
 struct ImageWithActivityIndicator_Previews: PreviewProvider {
     @available(iOS 13.0, *)
+    @available(watchOS 6.0, *)
     static var previews: some View {
         Text("not used")
     }

--- a/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
+++ b/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
@@ -11,8 +11,9 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 @available(watchOS 6.0, *)
+@available(OSX 10.15, *)
 public struct ViewWithActivityIndicator<Content:View> : View {
-    #if os(iOS)
+    #if !os(watchOS)
     private let style: UIActivityIndicatorView.Style = .medium
     #endif
 
@@ -38,7 +39,7 @@ public struct ViewWithActivityIndicator<Content:View> : View {
                     }
                     
                     if showActivityIndicator {
-                        #if os(iOS)
+                        #if !os(watchOS)
                         ActivityIndicator(style: .large)
                         #endif
                     }
@@ -61,6 +62,7 @@ public struct ViewWithActivityIndicator<Content:View> : View {
 struct ImageWithActivityIndicator_Previews: PreviewProvider {
     @available(iOS 13.0, *)
     @available(watchOS 6.0, *)
+    @available(OSX 10.15, *)
     static var previews: some View {
         Text("not used")
     }

--- a/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
+++ b/Sources/ImageWithActivityIndicator/ImageWithActivityIndicator.swift
@@ -20,10 +20,12 @@ public struct ViewWithActivityIndicator<Content:View> : View {
     @ObservedObject private var viewLoader:ViewLoader
     private var content: () -> Content
     private let placeHolder:String
+    private let aspectRatioHint:CGFloat
     private let showActivityIndicator:Bool
 
-    public init(placeHolder: String = "",showActivityIndicator:Bool = true, viewLoader:ViewLoader, @ViewBuilder _ content: @escaping () -> Content){
+    public init(placeHolder: String = "", aspectRatioHint: CGFloat = 1, showActivityIndicator:Bool = true, viewLoader:ViewLoader, @ViewBuilder _ content: @escaping () -> Content){
         self.placeHolder = placeHolder
+        self.aspectRatioHint = aspectRatioHint
         self.showActivityIndicator = showActivityIndicator
         self.viewLoader = viewLoader
         self.content = content
@@ -32,7 +34,12 @@ public struct ViewWithActivityIndicator<Content:View> : View {
     public var body: some View {
             ZStack(){
                 if  (viewLoader.data.isEmpty) {
-                    if (placeHolder != "") {
+                    if (placeHolder == "") {
+                        Rectangle()
+                            .fill(Color.white)
+                            .aspectRatio(self.aspectRatioHint, contentMode: .fit)
+                    }
+                    else {
                         Image(placeHolder)
                             .resizable()
                             .scaledToFit()
@@ -44,7 +51,7 @@ public struct ViewWithActivityIndicator<Content:View> : View {
                         #endif
                     }
                 }
-                else{
+                else {
                     content()
                 }
             }
@@ -60,11 +67,20 @@ public struct ViewWithActivityIndicator<Content:View> : View {
 #if DEBUG
 
 struct ImageWithActivityIndicator_Previews: PreviewProvider {
+    static let loader = ViewLoader(url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Apple_logo_black.svg/300px-Apple_logo_black.svg.png")
+    
     @available(iOS 13.0, *)
     @available(watchOS 6.0, *)
     @available(OSX 10.15, *)
     static var previews: some View {
-        Text("not used")
+        VStack {
+            ViewWithActivityIndicator(aspectRatioHint: 300 / 356, viewLoader: loader) {
+                Image(uiImage: UIImage(data: loader.getData()) ?? UIImage())
+            }
+            ViewWithActivityIndicator(viewLoader: ViewLoader(url: "foo")) {
+                Image(uiImage: UIImage())
+            }
+        }
     }
 }
 #endif

--- a/Sources/ImageWithActivityIndicator/ViewLoader.swift
+++ b/Sources/ImageWithActivityIndicator/ViewLoader.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 @available(iOS 13.0, *)
+@available(watchOS 6.0, *)
 public class ViewLoader: ObservableObject {
 
     @Published var data = Data()

--- a/Sources/ImageWithActivityIndicator/ViewLoader.swift
+++ b/Sources/ImageWithActivityIndicator/ViewLoader.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 @available(watchOS 6.0, *)
+@available(OSX 10.15, *)
 public class ViewLoader: ObservableObject {
 
     @Published var data = Data()

--- a/Sources/ImageWithActivityIndicator/ViewLoaders.swift
+++ b/Sources/ImageWithActivityIndicator/ViewLoaders.swift
@@ -6,6 +6,7 @@
 //
 
 @available(iOS 13.0, *)
+@available(watchOS 6.0, *)
 public struct ViewLoaders {
     var loaders: [ViewLoader] = []
     init(urls: [String]) {

--- a/Sources/ImageWithActivityIndicator/ViewLoaders.swift
+++ b/Sources/ImageWithActivityIndicator/ViewLoaders.swift
@@ -7,6 +7,7 @@
 
 @available(iOS 13.0, *)
 @available(watchOS 6.0, *)
+@available(OSX 10.15, *)
 public struct ViewLoaders {
     var loaders: [ViewLoader] = []
     init(urls: [String]) {


### PR DESCRIPTION
This PR makes it possible to use the plugin on macOS & watchOS. Previews compile, but are not displayed for images that use this component.

I had to disable the activity indicator functionality as it used APIs not available on watchOS.